### PR TITLE
used flexbox to make the card resize on mobile

### DIFF
--- a/src/app/category-playlists/category-playlists.component.html
+++ b/src/app/category-playlists/category-playlists.component.html
@@ -1,9 +1,9 @@
 <main role="main" class="container">
-    <div class="jumbotron" *ngIf="playlists">
-      <h1> {{ name }}</h1>
-      <span *ngFor="let item of playlists.items">
-       
-        <img src="{{ item.images[0].url }}" alt="{{ item.name }}" class="img-thumbnail rounded cursor" width="160px" (click)="open(item)" style="margin-right: 10px; margin-bottom:  10px">
-      </span>
+  <div class="jumbotron" *ngIf="playlists">
+    <h1> {{ name }}</h1>
+    <div class="flex-container">
+      <img *ngFor="let item of playlists.items" src="{{ item.images[0].url }}" alt="{{ item.name }}"
+        class="img-thumbnail rounded cursor self-sized-card" style="margin-right: 10px;margin-bottom: 10px;" (click)="open(item)">
     </div>
-  </main>
+  </div>
+</main>

--- a/src/app/genres-and-mood/genres-and-mood.component.html
+++ b/src/app/genres-and-mood/genres-and-mood.component.html
@@ -1,15 +1,14 @@
 <main role="main" class="container">
-    <div class="jumbotron" *ngIf="genres">
-      <h1>Genres & Moods</h1>
-      <div class="row">
-        <span *ngFor="let item of genres.categories.items" style="margin-right: 15px; margin-bottom: 15px;">
-          <span class="card cursor" style="width: 160px;" (click)="open(item)" >
-            <img class="card-img-top" src="{{ item.icons[0].url }}" alt="{{ item.name }}">
-            <div class="card-body">
-              <h5 class="card-title">{{ item.name}}</h5>
-            </div>
-          </span>
-        </span>
+  <div class="jumbotron" *ngIf="genres">
+    <h1>Genres & Moods</h1>
+    <div class="flex-container">
+      <div class="card cursor self-sized-card" *ngFor="let item of genres.categories.items"
+        style="margin-right: 10px; margin-bottom: 10px;" (click)="open(item)">
+        <img class="card-img-top" src="{{ item.icons[0].url }}" alt="{{ item.name }}">
+        <div class="card-body">
+          <h5 class="card-title">{{ item.name}}</h5>
+        </div>
       </div>
     </div>
-  </main>
+  </div>
+</main>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,10 @@
 <main role="main" class="container">
   <div class="jumbotron" *ngIf="featuredPlaylists">
     <h1> {{ featuredPlaylists.message }}</h1>
-    <span *ngFor="let item of featuredPlaylists.playlists.items">
-      <img src="{{ item.images[0].url }}" alt="{{ item.name }}" class="img-thumbnail rounded cursor" width="160px" (click)="open(item)" style="margin-right: 10px; margin-bottom:  10px">
-    </span>
+    <div class="flex-container">
+      <img *ngFor="let item of featuredPlaylists.playlists.items" src="{{ item.images[0].url }}" alt="{{ item.name }}"
+        class="img-thumbnail rounded cursor self-sized-card" (click)="open(item)"
+        style="margin-right: 10px; margin-bottom:  10px">
+    </div>
   </div>
 </main>

--- a/src/app/new-releases/new-releases.component.html
+++ b/src/app/new-releases/new-releases.component.html
@@ -1,16 +1,15 @@
 <main role="main" class="container">
   <div class="jumbotron" *ngIf="newReleased">
     <h1> New Released</h1>
-    <div class="row">
-      <span *ngFor="let item of newReleased.albums.items" style="margin-right: 15px; margin-bottom: 15px;">
-        <span class="card cursor" style="width: 160px; min-height: 308px;" (click)="open(item)">
+    <div class="flex-container">
+        <div class="card cursor self-sized-card" *ngFor="let item of newReleased.albums.items"
+         style="margin-right: 10px; margin-bottom: 10px;min-height: 308px;" (click)="open(item)">
           <img class="card-img-top" src="{{ item.images[0].url }}" alt="{{ item.name }}">
           <div class="card-body">
             <h5 class="card-title">{{ item.artists[0].name}}</h5>
             <p class="card-text">{{ item.name }}</p>
           </div>
-        </span>
-      </span>
+        </div>
     </div>
     <button type="button" class="btn btn-primary btn-lg btn-block" (click)="loadMore(newReleased)">Load more</button>
   </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,3 +23,24 @@ body {
 .cursor:hover {
     cursor: pointer;
 }
+
+
+
+
+.flex-container {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.flex-container .self-sized-card {
+  width: 160px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: auto;
+}
+
+@media(max-width: 768px) {
+  .flex-container .self-sized-card {
+      flex-grow: 1;
+  }    
+}


### PR DESCRIPTION
I added some global styles for css classes .flex-container and .self-sized-card, which will make a container flex and its items will have a fixed width of 160px on desktop devices or they will be able to grow to fill the container on devices with max-width of 768px.
Then I altered the views "home", "new-releases", "genres-and-mood" and "category-playlists" so they use this two classes to resize their cards.